### PR TITLE
Avoid `thread::spawn` in `CompatibleCiphers::new`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ thiserror = "1.0.37"
 tracing = "0.1.36"
 tokio-rustls = "0.23.4"
 rustls = { version = "0.20.6", features = ["secret_extraction"] }
-arrayvec = "0.7.2"
 smallvec = "1.10.0"
 memoffset = "0.6.5"
 pin-project-lite = "0.2.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ libc = "0.2.133"
 thiserror = "1.0.37"
 tracing = "0.1.36"
 tokio-rustls = "0.23.4"
-scopeguard = "1.1.0"
 rustls = { version = "0.20.6", features = ["secret_extraction"] }
 arrayvec = "0.7.2"
 smallvec = "1.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rustls = { version = "0.20.6", features = ["secret_extraction"] }
 arrayvec = "0.7.2"
 memoffset = "0.6.5"
 pin-project-lite = "0.2.9"
-tokio = { version = "1.21.2", features = ["net", "rt"] }
+tokio = { version = "1.21.2", features = ["net", "rt", "macros"] }
 futures = "0.3.24"
 
 [dependencies.ktls-sys]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ tokio-rustls = "0.23.4"
 scopeguard = "1.1.0"
 rustls = { version = "0.20.6", features = ["secret_extraction"] }
 arrayvec = "0.7.2"
+smallvec = "1.10.0"
 memoffset = "0.6.5"
 pin-project-lite = "0.2.9"
 tokio = { version = "1.21.2", features = ["net", "rt", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ arrayvec = "0.7.2"
 smallvec = "1.10.0"
 memoffset = "0.6.5"
 pin-project-lite = "0.2.9"
-tokio = { version = "1.21.2", features = ["net", "rt", "macros"] }
+tokio = { version = "1.21.2", features = ["net", "macros"] }
 futures = "0.3.24"
 
 [dependencies.ktls-sys]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,11 @@ libc = "0.2.133"
 thiserror = "1.0.37"
 tracing = "0.1.36"
 tokio-rustls = "0.23.4"
+scopeguard = "1.1.0"
 rustls = { version = "0.20.6", features = ["secret_extraction"] }
 memoffset = "0.6.5"
 pin-project-lite = "0.2.9"
-tokio = { version = "1.21.2", features = ["net"] }
+tokio = { version = "1.21.2", features = ["net", "rt"] }
 futures = "0.3.24"
 
 [dependencies.ktls-sys]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ tracing = "0.1.36"
 tokio-rustls = "0.23.4"
 scopeguard = "1.1.0"
 rustls = { version = "0.20.6", features = ["secret_extraction"] }
+arrayvec = "0.7.2"
 memoffset = "0.6.5"
 pin-project-lite = "0.2.9"
 tokio = { version = "1.21.2", features = ["net", "rt"] }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -206,7 +206,7 @@ impl<const N: usize> Cmsg<N> {
     fn new(level: i32, typ: i32, data: [u8; N]) -> Self {
         Self {
             hdr: libc::cmsghdr {
-                cmsg_len: (memoffset::offset_of!(Self, data) + N) as _,
+                cmsg_len: memoffset::offset_of!(Self, data) + N,
                 cmsg_level: level,
                 cmsg_type: typ,
             },

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -206,7 +206,7 @@ impl<const N: usize> Cmsg<N> {
     fn new(level: i32, typ: i32, data: [u8; N]) -> Self {
         Self {
             hdr: libc::cmsghdr {
-                cmsg_len: memoffset::offset_of!(Self, data) + N,
+                cmsg_len: (memoffset::offset_of!(Self, data) + N) as _,
                 cmsg_level: level,
                 cmsg_type: typ,
             },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,8 +61,8 @@ impl CompatibleCiphers {
             // Use biased here to optimize performance.
             //
             // With biased, tokio::select! would first poll create_connections_fut,
-            // which would poll all `TcpStream::connect` futures and establish
-            // connections to `ln` then returns `Poll::Pending`.
+            // which would poll all `TcpStream::connect` futures and requests
+            // new connections to `ln` then returns `Poll::Pending`.
             //
             // Then accept_conns_fut would be polled, which accepts all pending
             // connections, wake up create_connections_fut then returns

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,9 +176,6 @@ fn sample_cipher_setup(sock: &TcpStream, cipher_suite: SupportedCipherSuite) -> 
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("failed to connect to the tcp socket: {0}")]
-    ConnectionError(#[source] std::io::Error),
-
     #[error("failed to enable TLS ULP (upper level protocol): {0}")]
     UlpError(#[source] std::io::Error),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,15 +43,11 @@ impl CompatibleCiphers {
         let local_addr = ln.local_addr()?;
 
         async fn accept_conns(ln: TcpListener) {
-            let mut conns: [Option<TcpStream>; 8] =
-                [None, None, None, None, None, None, None, None];
-
-            let mut i = 0;
+            let mut conns = Vec::with_capacity(8);
 
             loop {
                 if let Ok((sock, _addr)) = ln.accept().await {
-                    conns[i] = Some(sock);
-                    i = (i + 1) % conns.len();
+                    conns.push(sock);
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-use arrayvec::ArrayVec;
 use ffi::{setup_tls_info, setup_ulp, KtlsCompatibilityError};
 use rustls::{Connection, ConnectionTrafficSecrets, SupportedCipherSuite};
 use smallvec::SmallVec;
@@ -44,7 +43,7 @@ impl CompatibleCiphers {
         let local_addr = ln.local_addr()?;
 
         // socks to the ln
-        let mut socks: ArrayVec<TcpStream, { Self::CIPHERS_COUNT }> = ArrayVec::new();
+        let mut socks: SmallVec<[TcpStream; Self::CIPHERS_COUNT]> = SmallVec::new();
         // Accepted conns of ln
         let mut accepted_conns: SmallVec<[TcpStream; Self::CIPHERS_COUNT]> = SmallVec::new();
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -23,7 +23,22 @@ const SERVER_PAYLOAD: &[u8] = b"this is the server speaking\n";
 
 #[tokio::test]
 async fn compatible_ciphers() {
-    let cc = ktls::CompatibleCiphers::new();
+    let cc = ktls::CompatibleCiphers::new().await.unwrap();
+    for suite in [
+        rustls::cipher_suite::TLS13_AES_128_GCM_SHA256,
+        rustls::cipher_suite::TLS13_AES_256_GCM_SHA384,
+        rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
+        rustls::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+        rustls::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+        rustls::cipher_suite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+    ] {
+        assert!(cc.is_compatible(&suite));
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn compatible_ciphers_single_thread() {
+    let cc = ktls::CompatibleCiphers::new().await.unwrap();
     for suite in [
         rustls::cipher_suite::TLS13_AES_128_GCM_SHA256,
         rustls::cipher_suite::TLS13_AES_256_GCM_SHA384,


### PR DESCRIPTION
 - Enable feature rt of dep tokio
 - Unify import from `std::os::unix`
 - Add new dep scopeguard v1.1.0
 - Make `CompatibleCiphers::new` async to avoid thread spawning and also return `io::Result<Self>` to avoid panic.
 - Fix `Error`: Add `#[source]` annotation
 - Refactor: Extract new async fn `CompatibleCiphers::test_ciphers`
 - Optimize `accept_conns`: keep them alive instead of reading from them.
 - Add test `compatible_ciphers_single_thread`

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>