### PR TITLE
Reproducing I/O errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ futures = "0.3.24"
 ktls-sys = "1.0.0"
 
 [dev-dependencies]
+const-random = "0.1.15"
 rcgen = "0.10.0"
 socket2 = "0.4.7"
 tokio = { version = "1.21.2", features = ["full"] }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use const_random::const_random;
 use rcgen::generate_simple_self_signed;
 use rustls::{
     cipher_suite::{
@@ -18,8 +19,8 @@ use tokio_rustls::TlsConnector;
 use tracing::{debug, Instrument};
 use tracing_subscriber::EnvFilter;
 
-const CLIENT_PAYLOAD: &[u8] = b"this is the client speaking\n";
-const SERVER_PAYLOAD: &[u8] = b"this is the server speaking\n";
+const CLIENT_PAYLOAD: &[u8] = &const_random!([u8; 32768]);
+const SERVER_PAYLOAD: &[u8] = &const_random!([u8; 32768]);
 
 #[tokio::test]
 async fn compatible_ciphers() {


### PR DESCRIPTION
This should trigger both `Message too long` and `Invalid argument` (appears to be random) mentioned in #20 

```
        FAIL [   0.013s] ktls::integration_test ktls_server_rustls_client_tls_1_3_aes_128_gcm
        FAIL [   0.013s] ktls::integration_test ktls_server_rustls_client_tls_1_3_aes_256_gcm
        FAIL [   0.012s] ktls::integration_test ktls_server_rustls_client_tls_1_3_chacha20_poly1305
```