### PR TITLE
Proper kTLS hand-off

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 jobs:
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## 2.0.0 (2023-03-29)
+
+Comes with a bunch of breaking changes, necessary to address some issues.
+
+Essentially, the rustls stream wasn't being drained properly in
+`config_ktls_{client,server}`. Doing this properly required introducing
+`CorkStream`, which is TLS-framing-aware.
+
+As a result, `config_ktls_*` functions now take a `TlsStream<CorkStream<IO>>`
+(where `IO` is typically `TcpStream`), and are async, since to properly drain we
+might need to read till the end of the last TLS messages rustls has partially
+buffered.
+
+## 1.0.1 (2022-10-21)
+
+Initial release.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ futures = "0.3.24"
 ktls-sys = "1.0.0"
 
 [dev-dependencies]
+const-random = "0.1.15"
 rcgen = "0.10.0"
 socket2 = "0.4.7"
 tokio = { version = "1.21.2", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,3 @@ rcgen = "0.10.0"
 socket2 = "0.4.7"
 tokio = { version = "1.21.2", features = ["full"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
-
-[patch.crates-io]
-# use rustls from ../rustls
-rustls = { path = "../rustls/rustls" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rustls = { version = "0.20.7", features = ["secret_extraction"] }
 smallvec = "1.10.0"
 memoffset = "0.6.5"
 pin-project-lite = "0.2.9"
-tokio = { version = "1.21.2", features = ["net", "macros"] }
+tokio = { version = "1.21.2", features = ["net", "macros", "io-util"] }
 futures = "0.3.24"
 ktls-sys = "1.0.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,7 @@ rcgen = "0.10.0"
 socket2 = "0.4.7"
 tokio = { version = "1.21.2", features = ["full"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
+
+[patch.crates-io]
+# use rustls from ../rustls
+rustls = { path = "../rustls/rustls" }

--- a/src/cork_stream.rs
+++ b/src/cork_stream.rs
@@ -1,0 +1,67 @@
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+pub struct CorkStream<IO> {
+    pub io: IO,
+    // if true, causes empty reads
+    pub corked: bool,
+}
+
+impl<IO> CorkStream<IO> {
+    pub fn new(io: IO) -> Self {
+        Self { io, corked: false }
+    }
+}
+
+impl<IO> AsyncRead for CorkStream<IO>
+where
+    IO: AsyncRead,
+{
+    #[inline]
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        if self.corked {
+            return Poll::Ready(Ok(()));
+        }
+
+        {
+            let io = unsafe { self.map_unchecked_mut(|s| &mut s.io) };
+            io.poll_read(cx, buf)
+        }
+    }
+}
+
+impl<IO> AsyncWrite for CorkStream<IO>
+where
+    IO: AsyncWrite,
+{
+    #[inline]
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let io = unsafe { self.map_unchecked_mut(|s| &mut s.io) };
+        io.poll_write(cx, buf)
+    }
+
+    #[inline]
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let io = unsafe { self.map_unchecked_mut(|s| &mut s.io) };
+        io.poll_flush(cx)
+    }
+
+    #[inline]
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let io = unsafe { self.map_unchecked_mut(|s| &mut s.io) };
+        io.poll_shutdown(cx)
+    }
+}

--- a/src/cork_stream.rs
+++ b/src/cork_stream.rs
@@ -42,10 +42,6 @@ where
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        // if self.corked {
-        //     return Poll::Ready(Ok(()));
-        // }
-
         let this = unsafe { self.get_unchecked_mut() };
         let mut io = unsafe { Pin::new_unchecked(&mut this.io) };
 

--- a/src/cork_stream.rs
+++ b/src/cork_stream.rs
@@ -4,17 +4,31 @@ use std::{
     task::{Context, Poll},
 };
 
+use rustls::internal::msgs::codec::Codec;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+enum State {
+    ReadHeader { header_buf: [u8; 5], offset: usize },
+    ReadPayload { msg_size: usize, offset: usize },
+}
 
 pub struct CorkStream<IO> {
     pub io: IO,
     // if true, causes empty reads
     pub corked: bool,
+    state: State,
 }
 
 impl<IO> CorkStream<IO> {
     pub fn new(io: IO) -> Self {
-        Self { io, corked: false }
+        Self {
+            io,
+            corked: false,
+            state: State::ReadHeader {
+                header_buf: Default::default(),
+                offset: 0,
+            },
+        }
     }
 }
 
@@ -28,13 +42,87 @@ where
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        if self.corked {
-            return Poll::Ready(Ok(()));
-        }
+        // if self.corked {
+        //     return Poll::Ready(Ok(()));
+        // }
 
-        {
-            let io = unsafe { self.map_unchecked_mut(|s| &mut s.io) };
-            io.poll_read(cx, buf)
+        let this = unsafe { self.get_unchecked_mut() };
+        let mut io = unsafe { Pin::new_unchecked(&mut this.io) };
+
+        let state = &mut this.state;
+
+        loop {
+            match state {
+                State::ReadHeader { header_buf, offset } => {
+                    if *offset == 0 && this.corked {
+                        tracing::trace!("corked, returning empty read");
+                        return Poll::Ready(Ok(()));
+                    }
+
+                    let left = header_buf.len() - *offset;
+                    tracing::trace!("reading header, {left}/{} bytes left", header_buf.len());
+
+                    {
+                        let mut rest = ReadBuf::new(&mut header_buf[*offset..]);
+                        futures::ready!(io.as_mut().poll_read(cx, &mut rest)?);
+                        if rest.filled().is_empty() {
+                            tracing::trace!("eof!");
+                            // FIXME: this should still put what we've read so far
+
+                            return Poll::Ready(Ok(()));
+                        }
+                        tracing::trace!("read {} bytes off of header", rest.filled().len());
+                        *offset += rest.filled().len();
+                    }
+
+                    if *offset == 5 {
+                        // TODO: error handling
+                        let typ =
+                            rustls::ContentType::read_bytes(&header_buf[0..1]).expect("valid typ");
+                        let version = rustls::ProtocolVersion::read_bytes(&header_buf[1..3])
+                            .expect("valid version");
+                        let len: u16 = u16::from_be_bytes(header_buf[3..5].try_into().unwrap());
+                        tracing::trace!("read header: typ={typ:?}, version={version:?}, len={len}");
+
+                        // TODO: handle cases where buffer is smalelr than 5,
+                        // as-is, this'll panic
+                        buf.put_slice(&header_buf[..]);
+                        *state = State::ReadPayload {
+                            msg_size: len as usize,
+                            offset: 0,
+                        };
+                        return Poll::Ready(Ok(()));
+                    } else {
+                        // keep trying
+                    }
+                }
+                State::ReadPayload { msg_size, offset } => {
+                    let rest = *msg_size - *offset;
+
+                    let just_read = {
+                        let mut rest = buf.take(rest);
+                        futures::ready!(io.as_mut().poll_read(cx, &mut rest)?);
+
+                        tracing::trace!("read {} bytes off of payload", rest.filled().len());
+                        *offset += rest.filled().len();
+
+                        if *offset == *msg_size {
+                            tracing::trace!("read full payload (all {} bytes)", *offset);
+                            *state = State::ReadHeader {
+                                header_buf: Default::default(),
+                                offset: 0,
+                            };
+                        }
+
+                        rest.filled().len()
+                    };
+
+                    let new_filled = buf.filled().len() + just_read;
+                    buf.set_filled(new_filled);
+
+                    return Poll::Ready(Ok(()));
+                }
+            }
         }
     }
 }

--- a/src/ktls_stream.rs
+++ b/src/ktls_stream.rs
@@ -68,6 +68,7 @@ where
         if let Some((drain_index, drained)) = this.drained.as_mut() {
             let drained = &drained[*drain_index..];
             let len = std::cmp::min(buf.remaining(), drained.len());
+
             tracing::trace!(%len, "KtlsStream::poll_read, can take from drain");
             buf.put_slice(&drained[..len]);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,8 +264,12 @@ fn drain(stream: &mut (dyn AsyncRead + Unpin)) -> Option<Vec<u8>> {
     }
 
     let filled_len = rb.filled().len();
-    drained.resize(filled_len, 0);
-    Some(drained)
+    if filled_len == 0 {
+        None
+    } else {
+        drained.resize(filled_len, 0);
+        Some(drained)
+    }
 }
 
 fn setup_inner(fd: RawFd, conn: Connection) -> Result<(), Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,6 +244,7 @@ fn drain(stream: &mut (dyn AsyncRead + Unpin)) -> Option<Vec<u8>> {
 
                 if new_filled == filled {
                     // EOF, already?
+                    tracing::debug!("EOF, stopping after having drained {filled} bytes");
                     break;
                 } else {
                     // keep going
@@ -256,10 +257,7 @@ fn drain(stream: &mut (dyn AsyncRead + Unpin)) -> Option<Vec<u8>> {
             }
             _ => {
                 // this would block, so we're done
-                tracing::debug!(
-                    "would block, stopping after having drained {} bytes",
-                    filled
-                );
+                tracing::debug!("would block, stopping after having drained {filled}",);
                 break;
             }
         }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -252,8 +252,9 @@ async fn client_test(
     cipher_suite: SupportedCipherSuite,
 ) {
     tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::new("rustls=trace,debug"))
+        // .with_env_filter(EnvFilter::new("rustls=trace,debug"))
         // .with_env_filter(EnvFilter::new("debug"))
+        .with_env_filter(EnvFilter::new("trace"))
         .pretty()
         .init();
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use const_random::const_random;
+use ktls::CorkStream;
 use rcgen::generate_simple_self_signed;
 use rustls::{
     cipher_suite::{
@@ -140,6 +141,7 @@ async fn server_test(
                 let (stream, addr) = ln.accept().await.unwrap();
                 debug!("Accepted TCP conn from {}", addr);
                 let stream = SpyStream(stream);
+                let stream = CorkStream::new(stream);
 
                 let stream = acceptor.accept(stream).await.unwrap();
                 debug!("Completed TLS handshake");
@@ -333,6 +335,7 @@ async fn client_test(
     let tls_connector = TlsConnector::from(Arc::new(client_config));
 
     let stream = TcpStream::connect(addr).await.unwrap();
+    let stream = CorkStream::new(stream);
 
     let stream = tls_connector
         .connect("localhost".try_into().unwrap(), stream)

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use const_random::const_random;
 use rcgen::generate_simple_self_signed;
 use rustls::{
     cipher_suite::{
@@ -18,8 +19,8 @@ use tokio_rustls::TlsConnector;
 use tracing::{debug, Instrument};
 use tracing_subscriber::EnvFilter;
 
-const CLIENT_PAYLOAD: &[u8] = b"this is the client speaking\n";
-const SERVER_PAYLOAD: &[u8] = b"this is the server speaking\n";
+const CLIENT_PAYLOAD: &[u8] = &const_random!([u8; 32768]);
+const SERVER_PAYLOAD: &[u8] = &const_random!([u8; 32768]);
 
 #[tokio::test]
 async fn compatible_ciphers() {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -23,8 +23,8 @@ use tokio_rustls::TlsConnector;
 use tracing::{debug, Instrument};
 use tracing_subscriber::EnvFilter;
 
-// const CLIENT_PAYLOAD: &[u8] = &const_random!([u8; 262144]);
-// const SERVER_PAYLOAD: &[u8] = &const_random!([u8; 262144]);
+const CLIENT_PAYLOAD: &[u8] = &const_random!([u8; 262144]);
+const SERVER_PAYLOAD: &[u8] = &const_random!([u8; 262144]);
 
 // const CLIENT_PAYLOAD: &[u8] = &const_random!([u8; 32768]);
 // const SERVER_PAYLOAD: &[u8] = &const_random!([u8; 32768]);
@@ -35,8 +35,8 @@ use tracing_subscriber::EnvFilter;
 // const CLIENT_PAYLOAD: &[u8] = &const_random!([u8; 512]);
 // const SERVER_PAYLOAD: &[u8] = &const_random!([u8; 512]);
 
-const CLIENT_PAYLOAD: &[u8] = b"I am the client";
-const SERVER_PAYLOAD: &[u8] = b"I am the server";
+// const CLIENT_PAYLOAD: &[u8] = b"I am the client";
+// const SERVER_PAYLOAD: &[u8] = b"I am the server";
 
 #[tokio::test]
 async fn compatible_ciphers() {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -23,8 +23,11 @@ use tokio_rustls::TlsConnector;
 use tracing::{debug, Instrument};
 use tracing_subscriber::EnvFilter;
 
-const CLIENT_PAYLOAD: &[u8] = &const_random!([u8; 262144]);
-const SERVER_PAYLOAD: &[u8] = &const_random!([u8; 262144]);
+// const CLIENT_PAYLOAD: &[u8] = &const_random!([u8; 262144]);
+// const SERVER_PAYLOAD: &[u8] = &const_random!([u8; 262144]);
+
+const CLIENT_PAYLOAD: &[u8] = &const_random!([u8; 32768]);
+const SERVER_PAYLOAD: &[u8] = &const_random!([u8; 32768]);
 
 #[tokio::test]
 async fn compatible_ciphers() {
@@ -92,7 +95,8 @@ async fn server_test(
 ) {
     tracing_subscriber::fmt()
         // .with_env_filter(EnvFilter::new("rustls=trace,debug"))
-        .with_env_filter(EnvFilter::new("debug"))
+        // .with_env_filter(EnvFilter::new("debug"))
+        .with_env_filter(EnvFilter::new("trace"))
         .pretty()
         .init();
 
@@ -138,7 +142,7 @@ async fn server_test(
                 let mut stream = ktls::config_ktls_server(stream).unwrap();
                 debug!("Configured kTLS");
 
-                assert!(stream.drained_remaining() < CLIENT_PAYLOAD.len());
+                // assert!(stream.drained_remaining() < CLIENT_PAYLOAD.len());
 
                 debug!("Reading data");
                 let mut buf = vec![0u8; CLIENT_PAYLOAD.len()];
@@ -369,14 +373,14 @@ where
             std::task::Poll::Ready(res) => match res {
                 Ok(_) => {
                     let num_read = buf.filled().len() - old_filled;
-                    tracing::debug!("read {num_read} bytes",);
+                    tracing::debug!("SpyStream read {num_read} bytes",);
                 }
                 Err(e) => {
-                    tracing::debug!("read errored: {e}");
+                    tracing::debug!("SpyStream read errored: {e}");
                 }
             },
             std::task::Poll::Pending => {
-                tracing::debug!("read would've blocked")
+                tracing::debug!("SpyStream read would've blocked")
             }
         }
         if let std::task::Poll::Ready(Ok(())) = res {}
@@ -401,14 +405,14 @@ where
         match &res {
             std::task::Poll::Ready(res) => match res {
                 Ok(n) => {
-                    tracing::debug!("wrote {n} bytes");
+                    tracing::debug!("SpyStream wrote {n} bytes");
                 }
                 Err(e) => {
-                    tracing::debug!("writing errored: {e}");
+                    tracing::debug!("SpyStream writing errored: {e}");
                 }
             },
             std::task::Poll::Pending => {
-                tracing::debug!("writing would've blocked")
+                tracing::debug!("SpyStream writing would've blocked")
             }
         }
         res


### PR DESCRIPTION
This branches off of #21 to aim to close #20.

This works by introducing a `CorkStream` abstraction that's aware of TLS message boundaries (works with both 1.2 and 1.3).

After the rustls handshake is "done", we try to set up ktls - but rustls may have already read some encrypted data off of the socket, and buffered it internally. It might even have decrypted some messages.

By the time we attempt to set up kTLS, we might have a case where the TLS connection:

  * A) Still has some decrypted messages it hasn't popped
  * B) Still has some data in the deframer's internal buffer that is only a partial message

"Draining" was supposed to fix "A", but couldn't fix "B" - that's where the "message too long" errors came from: kTLS was simply trying to decode a message starting from the middle (and the message length is just a u16).

Ideally we'd stop rustls reading more bytes than is strictly needed for the handshake to finish, but that's hard in TLS 1.3 where the end of the handshake is encrypted and wrapped in "ApplicationData" records. Without integrating deeper into rustls/replacing rustls altogether, it's impossible to tell where the "handshake/post-handshake encrypted exchanges" ends and where the "actual application data exchanges" begins.

So, we let rustls however many ApplicationData messages it buffered while performing the handshake, but after it's "returned from the future" (accept for servers, connect for clients), by the time we try setting up kTLS, and before draining, we "cork" the `CorkStream`, which is TLS-framing-aware and knows to stop right after the current frame is finished.

The code has a bunch of unwrap/expects that shouldn't be there, so it still needs cleaning up, and I think there's still an edge case where rustls has part of a message but needs to await (EWOULDBLOCK) to get the rest of it - this would again break ktls setup, leaving a partial message undecrypted in rustls' internal buffers, and returning EMSGSIZE, EINVAL, or whichever other kTLS failure mode.