### PR TITLE
Use recvmsg to handle/ignore control messages when poll_read fails

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ pin-project-lite = "0.2.9"
 tokio = { version = "1.28.2", features = ["net", "macros", "io-util"] }
 futures = "0.3.28"
 ktls-sys = "1.0.0"
+nix = { version = "0.26.2", features = ["socket", "uio", "net"], default-features = false }
 
 [dev-dependencies]
 const-random = "0.1.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ pin-project-lite = "0.2.9"
 tokio = { version = "1.28.2", features = ["net", "macros", "io-util"] }
 futures = "0.3.28"
 ktls-sys = "1.0.0"
-nix = { version = "0.26.2", features = ["socket", "uio", "net"], default-features = false }
+nix = { version = "0.26.1", features = ["socket", "uio", "net"], default-features = false }
 
 [dev-dependencies]
 const-random = "0.1.15"
@@ -30,3 +30,7 @@ rcgen = "0.10.0"
 socket2 = "0.5.3"
 tokio = { version = "1.28.2", features = ["full"] }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+
+[patch.crates-io]
+nix = { git = "https://github.com/fasterthanlime/nix", rev = "004d31c" } # on branch 'sol_tls'
+

--- a/src/async_read_ready.rs
+++ b/src/async_read_ready.rs
@@ -1,0 +1,12 @@
+use std::{io, task};
+
+pub trait AsyncReadReady {
+    /// cf. https://docs.rs/tokio/latest/tokio/net/struct.TcpStream.html#method.poll_read_ready
+    fn poll_read_ready(&self, cx: &mut task::Context<'_>) -> task::Poll<io::Result<()>>;
+}
+
+impl AsyncReadReady for tokio::net::TcpStream {
+    fn poll_read_ready(&self, cx: &mut task::Context<'_>) -> task::Poll<io::Result<()>> {
+        tokio::net::TcpStream::poll_read_ready(self, cx)
+    }
+}

--- a/src/ktls_stream.rs
+++ b/src/ktls_stream.rs
@@ -7,7 +7,7 @@ use std::{
 
 use nix::{
     cmsg_space,
-    sys::socket::{MsgFlags, SockaddrIn},
+    sys::socket::{ControlMessageOwned, MsgFlags, SockaddrIn},
 };
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
@@ -116,6 +116,14 @@ where
             }
         };
         tracing::trace!("recvmsg result = {:#?}", r);
+        let cmsg = r.cmsgs().next().unwrap();
+        let unknown_cmsg = match cmsg {
+            ControlMessageOwned::Unknown(unk) => unk,
+            _ => panic!("unexpected cmsg type: {cmsg:#?}"),
+        };
+        tracing::trace!("received {unknown_cmsg:#?}");
+        let msg_type = unknown_cmsg.1[0];
+
         let read_bytes = r.bytes;
 
         // FIXME: is that correct?

--- a/src/ktls_stream.rs
+++ b/src/ktls_stream.rs
@@ -110,6 +110,11 @@ where
         let r = nix::sys::socket::recvmsg::<SockaddrIn>(fd, &mut iov, Some(&mut cmsgspace), flags);
         let r = match r {
             Ok(r) => r,
+            Err(nix::errno::Errno::EAGAIN) => {
+                // this time don't `wake_by_ref` on purpose, but try to to clear readiness
+                return this.inner.poll_read_ready(cx);
+                // return task::Poll::Pending;
+            }
             Err(e) => {
                 tracing::trace!(?e, "recvmsg failed");
                 return Err(e.into()).into();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,9 @@ use tokio::{
 mod ffi;
 use crate::ffi::CryptoInfo;
 
+mod async_read_ready;
+pub use async_read_ready::AsyncReadReady;
+
 mod ktls_stream;
 pub use ktls_stream::KtlsStream;
 
@@ -203,7 +206,7 @@ pub async fn config_ktls_server<IO>(
     mut stream: tokio_rustls::server::TlsStream<CorkStream<IO>>,
 ) -> Result<KtlsStream<IO>, Error>
 where
-    IO: AsRawFd + AsyncRead + AsyncWrite + Unpin,
+    IO: AsRawFd + AsyncRead + AsyncReadReady + AsyncWrite + Unpin,
 {
     stream.get_mut().0.corked = true;
     let drained = drain(&mut stream).await.map_err(Error::DrainError)?;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -189,22 +189,22 @@ async fn server_test(
         .await
         .unwrap();
 
-    debug!("Client writing data");
+    debug!("Client writing data (1/4)");
     stream.write_all(CLIENT_PAYLOAD).await.unwrap();
     debug!("Flushing");
     stream.flush().await.unwrap();
 
-    debug!("Client reading data");
+    debug!("Client reading data (2/4)");
     let mut buf = vec![0u8; SERVER_PAYLOAD.len()];
     stream.read_exact(&mut buf).await.unwrap();
     assert_eq!(buf, SERVER_PAYLOAD);
 
-    debug!("Client writing data (again)");
+    debug!("Client writing data (3/4)");
     stream.write_all(CLIENT_PAYLOAD).await.unwrap();
     debug!("Flushing");
     stream.flush().await.unwrap();
 
-    debug!("Client reading data (again)");
+    debug!("Client reading data (4/4)");
     let mut buf = vec![0u8; SERVER_PAYLOAD.len()];
     stream.read_exact(&mut buf).await.unwrap();
     assert_eq!(buf, SERVER_PAYLOAD);
@@ -285,20 +285,25 @@ async fn client_test(
                 let mut stream = acceptor.accept(stream).await.unwrap();
                 debug!("Completed TLS handshake");
 
-                debug!("Server reading data");
+                debug!("Server reading data (1/4)");
                 let mut buf = vec![0u8; CLIENT_PAYLOAD.len()];
                 stream.read_exact(&mut buf).await.unwrap();
                 assert_eq!(buf, CLIENT_PAYLOAD);
 
-                debug!("Server writing data");
+                debug!("Server writing data (2/4)");
                 stream.write_all(SERVER_PAYLOAD).await.unwrap();
 
-                debug!("Server reading data");
+                debug!("Server reading data (3/4)");
                 let mut buf = vec![0u8; CLIENT_PAYLOAD.len()];
                 stream.read_exact(&mut buf).await.unwrap();
                 assert_eq!(buf, CLIENT_PAYLOAD);
 
-                debug!("Server writing data");
+                for _i in 0..3 {
+                    debug!("Making the client wait (to make busywaits REALLY obvious)");
+                    tokio::time::sleep(Duration::from_millis(250)).await;
+                }
+
+                debug!("Server writing data (4/4)");
                 stream.write_all(SERVER_PAYLOAD).await.unwrap();
                 stream.shutdown().await.unwrap();
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -270,6 +270,7 @@ async fn client_test(
         .unwrap();
 
     server_config.key_log = Arc::new(rustls::KeyLogFile::new());
+    server_config.send_tls13_tickets = 0;
 
     let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(server_config));
     let ln = TcpListener::bind("[::]:0").await.unwrap();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -268,7 +268,6 @@ async fn client_test(
         .unwrap();
 
     server_config.key_log = Arc::new(rustls::KeyLogFile::new());
-    server_config.send_tls13_tickets = 0;
 
     let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(server_config));
     let ln = TcpListener::bind("[::]:0").await.unwrap();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -270,7 +270,7 @@ async fn client_test(
         .unwrap();
 
     server_config.key_log = Arc::new(rustls::KeyLogFile::new());
-    server_config.send_tls13_tickets = 0;
+    // server_config.send_tls13_tickets = 0;
 
     let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(server_config));
     let ln = TcpListener::bind("[::]:0").await.unwrap();


### PR DESCRIPTION
Alternative to #25.

This is blocked on https://github.com/nix-rust/nix/pull/2065 + a nix crate release.