### PR TITLE
feat: Properly handle critical alerts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+*coverage*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ tokio = { version = "1.32.0", features = ["net", "macros", "io-util"] }
 futures = "0.3.28"
 ktls-sys = "1.0.0"
 ktls-recvmsg = { version = "0.1.3" }
+num_enum = "0.7.0"
 
 [dev-dependencies]
 const-random = "0.1.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ pin-project-lite = "0.2.13"
 tokio = { version = "1.32.0", features = ["net", "macros", "io-util"] }
 futures = "0.3.28"
 ktls-sys = "1.0.0"
-ktls-recvmsg = { version = "0.1.1" }
+ktls-recvmsg = { version = "0.1.3" }
 
 [dev-dependencies]
 const-random = "0.1.15"

--- a/Justfile
+++ b/Justfile
@@ -9,6 +9,11 @@ ci-test:
 	cargo llvm-cov nextest --lcov --output-path coverage.lcov
 	codecov
 
+# Show coverage locally
+cov:
+	#!/bin/bash -eux
+	cargo llvm-cov nextest --html --output-dir coverage
+
 # Run all tests
 test *args:
 	RUST_BACKTRACE=1 cargo nextest run {{args}}

--- a/src/ktls_stream.rs
+++ b/src/ktls_stream.rs
@@ -63,6 +63,34 @@ where
     }
 }
 
+#[derive(Debug, PartialEq, Clone, Copy, num_enum::FromPrimitive)]
+#[repr(u8)]
+enum TlsAlertLevel {
+    Warning = 1,
+    Fatal = 2,
+    #[num_enum(catch_all)]
+    Other(u8),
+}
+
+#[derive(Debug, PartialEq, Clone, Copy, num_enum::FromPrimitive)]
+#[repr(u8)]
+enum TlsAlertDescription {
+    CloseNotify = 0,
+    #[num_enum(catch_all)]
+    Other(u8),
+}
+
+#[derive(Debug, PartialEq, Clone, Copy, num_enum::FromPrimitive)]
+#[repr(u8)]
+enum TlsRecordType {
+    ChangeCipherSpec = 20,
+    Alert = 21,
+    Handshake = 22,
+    ApplicationData = 23,
+    #[num_enum(catch_all)]
+    Other(u8),
+}
+
 impl<IO> AsyncRead for KtlsStream<IO>
 where
     IO: AsRawFd + AsyncRead + AsyncReadReady,
@@ -75,6 +103,10 @@ where
         tracing::trace!(buf.remaining = %buf.remaining(), "KtlsStream::poll_read");
 
         if self.read_closed {
+            return task::Poll::Ready(Ok(()));
+        }
+
+        if buf.remaining() == 0 {
             return task::Poll::Ready(Ok(()));
         }
 
@@ -136,120 +168,88 @@ where
                     .cmsgs()
                     .next()
                     .expect("we should've received exactly one control message");
-                match cmsg {
-                    // cf. RFC 5246, Section 6.2.1
-                    // https://datatracker.ietf.org/doc/html/rfc5246#section-6.2.1
-                    ControlMessageOwned::TlsGetRecordType(t) => {
-                        match t {
-                            // change_cipher_spec
-                            20 => {
-                                panic!(
-                                    "received TLS change_cipher_spec, this isn't supported by ktls"
-                                )
-                            }
-                            // alert
-                            21 => {
-                                let iov = r.iovs().next().expect("expected data in iovs");
 
+                let record_type = match cmsg {
+                    ControlMessageOwned::TlsGetRecordType(t) => t,
+                    _ => panic!("unexpected cmsg type: {cmsg:#?}"),
+                };
+
+                match TlsRecordType::from_primitive(record_type) {
+                    TlsRecordType::ChangeCipherSpec => {
+                        panic!("change_cipher_spec isn't supported by the ktls crate")
+                    }
+                    TlsRecordType::Alert => {
+                        // the alert level and description are in iovs
+                        let iov = r.iovs().next().expect("expected data in iovs");
+
+                        let (level, description) = match iov {
+                            [] => {
+                                // we have an early return case for that
+                                unreachable!();
+                            }
+                            &[level] => {
                                 // https://github.com/facebookincubator/fizz/blob/fff6d9d49d3c554ab66b58822d1e1fe93e8d80f2/fizz/experimental/ktls/AsyncKTLSSocket.cpp#L144
-                                // We do not buffer alerts that could not be
-                                // fully read.
-                                //
-                                // This situation can only happen if the user
-                                // supplies a buffer smaller than 2 bytes.
-                                //
-                                // If we *start* reading an alert, then it is
-                                // *guaranteed* that the kernel has the actual
-                                // full contents of the alert in the kernel
-                                // buffer, since kTLS operates one record at a
-                                // time (it does not signal socket readability
-                                // until there exists at least one full record).
                                 //
                                 // Since all alerts (even warning-level alerts)
                                 // signal the abort of a TLS session, we do not
                                 // need to worry about additional application
                                 // data.
-                                if iov.len() < 2 {
-                                    *this.read_closed = true;
-                                    *this.write_closed = true;
-                                    if let Err(e) =
-                                        crate::ffi::send_close_notify(this.inner.as_raw_fd())
-                                    {
-                                        return Err(e).into();
-                                    }
-                                    unsafe { libc::close(fd) };
-                                    return task::Poll::Ready(Ok(()));
-                                }
-
-                                #[derive(
-                                    Debug, PartialEq, Clone, Copy, num_enum::FromPrimitive,
-                                )]
-                                #[repr(u8)]
-                                enum AlertLevel {
-                                    Warning = 1,
-                                    Fatal = 2,
-                                    #[num_enum(catch_all)]
-                                    Other(u8),
-                                }
-
-                                #[derive(
-                                    Debug, PartialEq, Clone, Copy, num_enum::FromPrimitive,
-                                )]
-                                #[repr(u8)]
-                                enum AlertDescription {
-                                    CloseNotify = 0,
-                                    #[num_enum(catch_all)]
-                                    Other(u8),
-                                }
-
-                                let [level, description]: [u8; 2] = iov[..2]
-                                    .try_into()
-                                    .expect("expected at least 2 bytes in iov");
-
-                                let level = AlertLevel::from_primitive(level);
-                                let description = AlertDescription::from_primitive(description);
-
-                                match (level, description) {
-                                    // https://datatracker.ietf.org/doc/html/rfc5246#section-7.2
-                                    // alerts we should handle are ones with fatal level or a
-                                    // close_notify
-                                    (_, AlertDescription::CloseNotify) | (AlertLevel::Fatal, _) => {
-                                        tracing::trace!(?level, ?description, "got TLS alert");
-                                        *this.read_closed = true;
-                                        *this.write_closed = true;
-                                        if let Err(e) =
-                                            crate::ffi::send_close_notify(this.inner.as_raw_fd())
-                                        {
-                                            return Err(e).into();
-                                        }
-                                        unsafe { libc::close(fd) };
-                                    }
-                                    _ => {
-                                        // we got something we probably can't handle
-                                    }
-                                }
-                                return task::Poll::Ready(Ok(()));
+                                //
+                                // If we only have half the alert (because the
+                                // user passed a buffer of size 1), just assume
+                                // it's a close_notify
+                                (
+                                    TlsAlertLevel::from_primitive(level),
+                                    TlsAlertDescription::CloseNotify,
+                                )
                             }
-                            // handshake
-                            22 => {
-                                // TODO: this is where we receive TLS 1.3 resumption tickets,
-                                // should those be stored anywhere? I'm not even sure what
-                                // format they have at this point
-                                tracing::trace!(
-                                    "ignoring handshake message (probably a resumption ticket)"
+                            &[level, description] => (
+                                TlsAlertLevel::from_primitive(level),
+                                TlsAlertDescription::from_primitive(description),
+                            ),
+                            _ => {
+                                unreachable!(
+                                    "TLS alerts are exactly 2 bytes, your kTLS is misbehaving"
                                 );
                             }
-                            // application data
-                            23 => {
-                                unreachable!("received TLS application in recvmsg, this is supposed to happen in the poll_read codepath")
+                        };
+
+                        match (level, description) {
+                            // https://datatracker.ietf.org/doc/html/rfc5246#section-7.2
+                            // alerts we should handle are ones with fatal level or a
+                            // close_notify
+                            (_, TlsAlertDescription::CloseNotify) | (TlsAlertLevel::Fatal, _) => {
+                                tracing::trace!(?level, ?description, "got TLS alert");
+                                *this.read_closed = true;
+                                *this.write_closed = true;
+                                if let Err(e) =
+                                    crate::ffi::send_close_notify(this.inner.as_raw_fd())
+                                {
+                                    return Err(e).into();
+                                }
+                                unsafe { libc::close(fd) };
                             }
                             _ => {
-                                // just ignore the message type then
-                                tracing::trace!("received message_type {t:#?}");
+                                // we got something we probably can't handle
                             }
                         }
+                        return task::Poll::Ready(Ok(()));
                     }
-                    _ => panic!("unexpected cmsg type: {cmsg:#?}"),
+                    TlsRecordType::Handshake => {
+                        // TODO: this is where we receive TLS 1.3 resumption tickets,
+                        // should those be stored anywhere? I'm not even sure what
+                        // format they have at this point
+                        tracing::trace!(
+                            "ignoring handshake message (probably a resumption ticket)"
+                        );
+                    }
+                    TlsRecordType::ApplicationData => {
+                        unreachable!("received TLS application in recvmsg, this is supposed to happen in the poll_read codepath")
+                    }
+                    TlsRecordType::Other(t) => {
+                        // just ignore the record?
+                        tracing::trace!("received record_type {t:#?}");
+                    }
                 };
 
                 // FIXME: this is hacky, but can we do better?

--- a/src/ktls_stream.rs
+++ b/src/ktls_stream.rs
@@ -1,4 +1,5 @@
 use ktls_recvmsg::{recvmsg, ControlMessageOwned, Errno, MsgFlags, SockaddrIn};
+use num_enum::FromPrimitive;
 use std::{
     io::{self, IoSliceMut},
     os::unix::prelude::AsRawFd,
@@ -18,7 +19,8 @@ pin_project_lite::pin_project! {
     {
         #[pin]
         inner: IO,
-        close_notified: bool,
+        write_closed: bool,
+        read_closed: bool,
         drained: Option<(usize, Vec<u8>)>,
     }
 }
@@ -30,7 +32,8 @@ where
     pub fn new(inner: IO, drained: Option<Vec<u8>>) -> Self {
         Self {
             inner,
-            close_notified: false,
+            write_closed: false,
+            read_closed: false,
             drained: drained.map(|drained| (0, drained)),
         }
     }
@@ -70,6 +73,10 @@ where
         buf: &mut ReadBuf<'_>,
     ) -> task::Poll<io::Result<()>> {
         tracing::trace!(buf.remaining = %buf.remaining(), "KtlsStream::poll_read");
+
+        if self.read_closed {
+            return task::Poll::Ready(Ok(()));
+        }
 
         let mut this = self.project();
 
@@ -142,35 +149,86 @@ where
                             }
                             // alert
                             21 => {
-                                // https://github.com/facebookincubator/fizz/blob/fff6d9d49d3c554ab66b58822d1e1fe93e8d80f2/fizz/experimental/ktls/AsyncKTLSSocket.cpp#L144
-                                // We should be able to read from iov now at least 2 bytes
-                                match r.iovs().next() {
-                                    Some(alert) => {
-                                        // https://datatracker.ietf.org/doc/html/rfc5246#section-7.2
-                                        // alerts we should handle are ones with fatal level or a
-                                        // close_notify
-                                        if alert.len() < 2 {
-                                            _ = crate::ffi::send_close_notify(this.inner.as_raw_fd());
-                                            unsafe { libc::close(fd) };
-                                            return task::Poll::Ready(Err(std::io::Error::new(io::ErrorKind::InvalidInput, "Ktls sent alert with invalid size")));
-                                        }
+                                let iov = r.iovs().next().expect("expected data in iovs");
 
-                                        // alert layout: [level, description]
-                                        // if we get a close_notify() or an alert with fatal level
-                                        // we should close session
-                                        if alert[1] == 0
-                                            || alert[0] == 2 {
-                                            _ = crate::ffi::send_close_notify(this.inner.as_raw_fd());
-                                            unsafe { libc::close(fd) };
-                                        } else {
-                                            // We got something we probably can't handle
+                                // https://github.com/facebookincubator/fizz/blob/fff6d9d49d3c554ab66b58822d1e1fe93e8d80f2/fizz/experimental/ktls/AsyncKTLSSocket.cpp#L144
+                                // We do not buffer alerts that could not be
+                                // fully read.
+                                //
+                                // This situation can only happen if the user
+                                // supplies a buffer smaller than 2 bytes.
+                                //
+                                // If we *start* reading an alert, then it is
+                                // *guaranteed* that the kernel has the actual
+                                // full contents of the alert in the kernel
+                                // buffer, since kTLS operates one record at a
+                                // time (it does not signal socket readability
+                                // until there exists at least one full record).
+                                //
+                                // Since all alerts (even warning-level alerts)
+                                // signal the abort of a TLS session, we do not
+                                // need to worry about additional application
+                                // data.
+                                if iov.len() < 2 {
+                                    *this.read_closed = true;
+                                    *this.write_closed = true;
+                                    if let Err(e) =
+                                        crate::ffi::send_close_notify(this.inner.as_raw_fd())
+                                    {
+                                        return Err(e).into();
+                                    }
+                                    unsafe { libc::close(fd) };
+                                    return task::Poll::Ready(Ok(()));
+                                }
+
+                                #[derive(
+                                    Debug, PartialEq, Clone, Copy, num_enum::FromPrimitive,
+                                )]
+                                #[repr(u8)]
+                                enum AlertLevel {
+                                    Warning = 1,
+                                    Fatal = 2,
+                                    #[num_enum(catch_all)]
+                                    Other(u8),
+                                }
+
+                                #[derive(
+                                    Debug, PartialEq, Clone, Copy, num_enum::FromPrimitive,
+                                )]
+                                #[repr(u8)]
+                                enum AlertDescription {
+                                    CloseNotify = 0,
+                                    #[num_enum(catch_all)]
+                                    Other(u8),
+                                }
+
+                                let [level, description]: [u8; 2] = iov[..2]
+                                    .try_into()
+                                    .expect("expected at least 2 bytes in iov");
+
+                                let level = AlertLevel::from_primitive(level);
+                                let description = AlertDescription::from_primitive(description);
+
+                                match (level, description) {
+                                    // https://datatracker.ietf.org/doc/html/rfc5246#section-7.2
+                                    // alerts we should handle are ones with fatal level or a
+                                    // close_notify
+                                    (_, AlertDescription::CloseNotify) | (AlertLevel::Fatal, _) => {
+                                        tracing::trace!(?level, ?description, "got TLS alert");
+                                        *this.read_closed = true;
+                                        *this.write_closed = true;
+                                        if let Err(e) =
+                                            crate::ffi::send_close_notify(this.inner.as_raw_fd())
+                                        {
+                                            return Err(e).into();
                                         }
-                                        return task::Poll::Ready(Ok(()));
-                                    },
-                                    None => {
-                                        panic!("ktls sent an invalid alert message");
+                                        unsafe { libc::close(fd) };
+                                    }
+                                    _ => {
+                                        // we got something we probably can't handle
                                     }
                                 }
+                                return task::Poll::Ready(Ok(()));
                             }
                             // handshake
                             22 => {
@@ -196,7 +254,7 @@ where
 
                 // FIXME: this is hacky, but can we do better?
                 // after we handled (..ignored) the control message, we don't
-                // know whether the scoket is still ready to be read or not.
+                // know whether the socket is still ready to be read or not.
                 //
                 // we could try looping (tricky code structure), but we can't,
                 // for example, just call `poll_read`, which might fail not
@@ -220,6 +278,10 @@ where
         cx: &mut task::Context<'_>,
         buf: &[u8],
     ) -> task::Poll<io::Result<usize>> {
+        if self.write_closed {
+            return task::Poll::Ready(Ok(0));
+        }
+
         self.project().inner.poll_write(cx, buf)
     }
 
@@ -233,10 +295,8 @@ where
     ) -> task::Poll<io::Result<()>> {
         let this = self.project();
 
-        if !*this.close_notified {
-            // setting this optimistically, I don't think calling it more than
-            // once is going to help if it failed the first time.
-            *this.close_notified = true;
+        if !*this.write_closed {
+            *this.write_closed = true;
             if let Err(e) = crate::ffi::send_close_notify(this.inner.as_raw_fd()) {
                 return Err(e).into();
             }

--- a/src/ktls_stream.rs
+++ b/src/ktls_stream.rs
@@ -300,6 +300,9 @@ where
             if let Err(e) = crate::ffi::send_close_notify(this.inner.as_raw_fd()) {
                 return Err(e).into();
             }
+            if *this.read_closed {
+                unsafe { libc::close(this.inner.as_raw_fd()) };
+            }
         }
 
         this.inner.poll_shutdown(cx)

--- a/src/ktls_stream.rs
+++ b/src/ktls_stream.rs
@@ -228,6 +228,7 @@ where
                                     return Err(e).into();
                                 }
                                 unsafe { libc::close(fd) };
+                                return task::Poll::Ready(Ok(()));
                             }
                             _ => {
                                 // we got something we probably can't handle

--- a/src/ktls_stream.rs
+++ b/src/ktls_stream.rs
@@ -297,15 +297,15 @@ where
         let this = self.project();
 
         if !*this.write_closed {
+            // they didn't hang up on us, we're nicely being asked to shut down,
+            // let's send a close_notify (and not wait for them to send it back)
             *this.write_closed = true;
             if let Err(e) = crate::ffi::send_close_notify(this.inner.as_raw_fd()) {
                 return Err(e).into();
             }
-            if *this.read_closed {
-                unsafe { libc::close(this.inner.as_raw_fd()) };
-            }
         }
 
+        // this ends up closing the inner file descriptor no matter what
         this.inner.poll_shutdown(cx)
     }
 }

--- a/src/ktls_stream.rs
+++ b/src/ktls_stream.rs
@@ -227,7 +227,9 @@ where
                                 {
                                     return Err(e).into();
                                 }
-                                unsafe { libc::close(fd) };
+                                // the file descriptor will be closed when the stream is dropped,
+                                // we already protect against writes-after-close_notify through
+                                // the write_closed flag
                                 return task::Poll::Ready(Ok(()));
                             }
                             _ => {

--- a/src/ktls_stream.rs
+++ b/src/ktls_stream.rs
@@ -150,7 +150,9 @@ where
                                         // alerts we should handle are ones with fatal level or a
                                         // close_notify
                                         if alert.len() < 2 {
-                                            panic!("ktls sent an alert with invalid size");
+                                            _ = crate::ffi::send_close_notify(this.inner.as_raw_fd());
+                                            unsafe { libc::close(fd) };
+                                            return task::Poll::Ready(Err(std::io::Error::new(io::ErrorKind::InvalidInput, "Ktls sent alert with invalid size")));
                                         }
 
                                         // alert layout: [level, description]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -165,7 +165,7 @@ async fn server_test(
                 stream.flush().await.unwrap();
                 
                 debug!("Server reading from closed session (5/5)");
-                assert_eq!(stream.read_exact(&mut buf[..1]).await.is_err(), true);
+                assert!(stream.read_exact(&mut buf[..1]).await.is_err(), "Session still open?");
             }
         }
         .instrument(tracing::info_span!("server")),
@@ -374,7 +374,7 @@ async fn client_test(
     assert_eq!(buf, SERVER_PAYLOAD);
 
     debug!("Client reading from closed session");
-    assert_eq!(stream.read_exact(&mut buf[..1]).await.is_err(), true);
+    assert!(stream.read_exact(&mut buf[..1]).await.is_err(), "Session still open?");
 }
 
 struct SpyStream<IO>(IO, &'static str);


### PR DESCRIPTION
Currently, there is no check on alerts received from recvmsg, even those that require to close session as per the rfc.
This commit adds alerts case handling when session termination is necessary.