### PR TITLE
fix!: Remove drained_remaining public method

### DIFF
--- a/src/ktls_stream.rs
+++ b/src/ktls_stream.rs
@@ -52,15 +52,6 @@ where
     pub fn get_mut(&mut self) -> &mut IO {
         &mut self.inner
     }
-
-    /// Returns the number of bytes that have been drained from rustls but not yet read.
-    /// Only really used in integration tests.
-    pub fn drained_remaining(&self) -> usize {
-        match self.drained.as_ref() {
-            Some((offset, v)) => v.len() - offset,
-            None => 0,
-        }
-    }
 }
 
 #[derive(Debug, PartialEq, Clone, Copy, num_enum::FromPrimitive)]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -168,8 +168,6 @@ async fn server_test_inner(
             let mut stream = ktls::config_ktls_server(stream).await.unwrap();
             debug!("Configured kTLS");
 
-            // assert!(stream.drained_remaining() < CLIENT_PAYLOAD.len());
-
             debug!("Server reading data (1/5)");
             let mut buf = vec![0u8; CLIENT_PAYLOAD.len()];
             stream.read_exact(&mut buf).await.unwrap();


### PR DESCRIPTION
It's unnecessary