### PR TITLE
chore!: Bump to rustls 0.22, tokio-rustls 0.25

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,8 @@ jobs:
         run: |
           cd ${{ github.workspace }}
           cargo clippy
-          just ci-test
+          # show backtraces
+          RUST_BACKTRACE=1 just ci-test
       - name: Upload coverage information
         run: |
           curl -Os https://uploader.codecov.io/latest/linux/codecov 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,23 +620,32 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustls"
-version = "0.21.10"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
 dependencies = [
  "log",
  "ring 0.17.8",
+ "rustls-pki-types",
  "rustls-webpki",
- "sct",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
-name = "rustls-webpki"
-version = "0.101.7"
+name = "rustls-pki-types"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
 dependencies = [
  "ring 0.17.8",
+ "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -645,16 +654,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
-]
 
 [[package]]
 name = "serde"
@@ -730,6 +729,12 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
@@ -823,11 +828,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
  "rustls",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -1174,3 +1180,9 @@ checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
  "time",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ libc = { version = "0.2.148", features = ["const-extern-fn"] }
 thiserror = "1.0.49"
 tracing = "0.1.37"
 tokio-rustls = "0.25.0"
-rustls = { version = "0.22" }
+rustls = { version = "0.22.2" }
 smallvec = "1.11.1"
 memoffset = "0.9.0"
 pin-project-lite = "0.2.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ Configures kTLS for tokio-rustls client and server connections.
 libc = { version = "0.2.148", features = ["const-extern-fn"] }
 thiserror = "1.0.49"
 tracing = "0.1.37"
-tokio-rustls = "0.24.1"
-rustls = { version = "0.21.7", features = ["secret_extraction"] }
+tokio-rustls = "0.25.0"
+rustls = { version = "0.22" }
 smallvec = "1.11.1"
 memoffset = "0.9.0"
 pin-project-lite = "0.2.13"

--- a/Justfile
+++ b/Justfile
@@ -16,3 +16,6 @@ cov:
 # Run all tests
 test *args:
 	RUST_BACKTRACE=1 cargo nextest run {{args}}
+
+check:
+	cargo clippy --all-features --all-targets

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -10,12 +10,8 @@ use ktls::{AsyncReadReady, CorkStream};
 use lazy_static::lazy_static;
 use rcgen::generate_simple_self_signed;
 use rustls::{
-    cipher_suite::{
-        TLS13_AES_128_GCM_SHA256, TLS13_AES_256_GCM_SHA384, TLS13_CHACHA20_POLY1305_SHA256,
-        TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-        TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
-    },
     client::Resumption,
+    crypto::ring::cipher_suite::{self},
     version::{TLS12, TLS13},
     ClientConfig, RootCertStore, ServerConfig, SupportedCipherSuite, SupportedProtocolVersion,
 };
@@ -59,12 +55,12 @@ lazy_static! {
 async fn compatible_ciphers() {
     let cc = ktls::CompatibleCiphers::new().await.unwrap();
     for suite in [
-        rustls::cipher_suite::TLS13_AES_128_GCM_SHA256,
-        rustls::cipher_suite::TLS13_AES_256_GCM_SHA384,
-        rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
-        rustls::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-        rustls::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-        rustls::cipher_suite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+        cipher_suite::TLS13_AES_128_GCM_SHA256,
+        cipher_suite::TLS13_AES_256_GCM_SHA384,
+        cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
+        cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+        cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+        cipher_suite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
     ] {
         assert!(cc.is_compatible(&suite));
     }
@@ -74,12 +70,12 @@ async fn compatible_ciphers() {
 async fn compatible_ciphers_single_thread() {
     let cc = ktls::CompatibleCiphers::new().await.unwrap();
     for suite in [
-        rustls::cipher_suite::TLS13_AES_128_GCM_SHA256,
-        rustls::cipher_suite::TLS13_AES_256_GCM_SHA384,
-        rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
-        rustls::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-        rustls::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-        rustls::cipher_suite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+        cipher_suite::TLS13_AES_128_GCM_SHA256,
+        cipher_suite::TLS13_AES_256_GCM_SHA384,
+        cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
+        cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+        cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+        cipher_suite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
     ] {
         assert!(cc.is_compatible(&suite));
     }
@@ -87,32 +83,44 @@ async fn compatible_ciphers_single_thread() {
 
 #[tokio::test]
 async fn ktls_server_rustls_client_tls_1_3_aes_128_gcm() {
-    server_test(&TLS13, TLS13_AES_128_GCM_SHA256).await;
+    server_test(&TLS13, cipher_suite::TLS13_AES_128_GCM_SHA256).await;
 }
 
 #[tokio::test]
 async fn ktls_server_rustls_client_tls_1_3_aes_256_gcm() {
-    server_test(&TLS13, TLS13_AES_256_GCM_SHA384).await;
+    server_test(&TLS13, cipher_suite::TLS13_AES_256_GCM_SHA384).await;
 }
 
 #[tokio::test]
 async fn ktls_server_rustls_client_tls_1_3_chacha20_poly1305() {
-    server_test(&TLS13, TLS13_CHACHA20_POLY1305_SHA256).await;
+    server_test(&TLS13, cipher_suite::TLS13_CHACHA20_POLY1305_SHA256).await;
 }
 
 #[tokio::test]
 async fn ktls_server_rustls_client_tls_1_2_ecdhe_aes_128_gcm() {
-    server_test(&TLS12, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256).await;
+    server_test(
+        &TLS12,
+        cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+    )
+    .await;
 }
 
 #[tokio::test]
 async fn ktls_server_rustls_client_tls_1_2_ecdhe_aes_256_gcm() {
-    server_test(&TLS12, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384).await;
+    server_test(
+        &TLS12,
+        cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+    )
+    .await;
 }
 
 #[tokio::test]
 async fn ktls_server_rustls_client_tls_1_2_ecdhe_chacha20_poly1305() {
-    server_test(&TLS12, TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256).await;
+    server_test(
+        &TLS12,
+        cipher_suite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+    )
+    .await;
 }
 
 #[derive(Clone, Copy)]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -11,7 +11,8 @@ use lazy_static::lazy_static;
 use rcgen::generate_simple_self_signed;
 use rustls::{
     client::Resumption,
-    crypto::ring::cipher_suite::{self},
+    crypto::{ring::cipher_suite, CryptoProvider},
+    pki_types::CertificateDer,
     version::{TLS12, TLS13},
     ClientConfig, RootCertStore, ServerConfig, SupportedCipherSuite, SupportedProtocolVersion,
 };
@@ -165,17 +166,18 @@ async fn server_test_inner(
     println!("{}", cert.serialize_pem().unwrap());
     println!("{}", cert.serialize_private_key_pem());
 
-    let mut server_config = ServerConfig::builder()
-        .with_cipher_suites(&[cipher_suite])
-        .with_safe_default_kx_groups()
-        .with_protocol_versions(&[protocol_version])
-        .unwrap()
-        .with_no_client_auth()
-        .with_single_cert(
-            vec![rustls::Certificate(cert.serialize_der().unwrap())],
-            rustls::PrivateKey(cert.serialize_private_key_der()),
-        )
-        .unwrap();
+    let mut server_config = ServerConfig::builder_with_provider(Arc::new(CryptoProvider {
+        cipher_suites: vec![cipher_suite],
+        ..rustls::crypto::ring::default_provider()
+    }))
+    .with_protocol_versions(&[protocol_version])
+    .unwrap()
+    .with_no_client_auth()
+    .with_single_cert(
+        vec![CertificateDer::from(cert.serialize_der().unwrap())],
+        rustls::pki_types::PrivatePkcs8KeyDer::from(cert.serialize_private_key_der()).into(),
+    )
+    .unwrap();
 
     server_config.enable_secret_extraction = true;
     server_config.key_log = Arc::new(rustls::KeyLogFile::new());
@@ -243,17 +245,13 @@ async fn server_test_inner(
         .instrument(tracing::info_span!("server")),
     );
 
-    let mut root_certs = RootCertStore::empty();
-    root_certs
-        .add(&rustls::Certificate(cert.serialize_der().unwrap()))
+    let mut root_store = RootCertStore::empty();
+    root_store
+        .add(CertificateDer::from(cert.serialize_der().unwrap()))
         .unwrap();
 
     let client_config = ClientConfig::builder()
-        .with_safe_default_cipher_suites()
-        .with_safe_default_kx_groups()
-        .with_safe_default_protocol_versions()
-        .unwrap()
-        .with_root_certificates(root_certs)
+        .with_root_certificates(root_store)
         .with_no_client_auth();
 
     let tls_connector = TlsConnector::from(Arc::new(client_config));
@@ -306,32 +304,44 @@ async fn server_test_inner(
 
 #[tokio::test]
 async fn ktls_client_rustls_server_tls_1_3_aes_128_gcm() {
-    client_test(&TLS13, TLS13_AES_128_GCM_SHA256).await;
+    client_test(&TLS13, cipher_suite::TLS13_AES_128_GCM_SHA256).await;
 }
 
 #[tokio::test]
 async fn ktls_client_rustls_server_tls_1_3_aes_256_gcm() {
-    client_test(&TLS13, TLS13_AES_256_GCM_SHA384).await;
+    client_test(&TLS13, cipher_suite::TLS13_AES_256_GCM_SHA384).await;
 }
 
 #[tokio::test]
 async fn ktls_client_rustls_server_tls_1_3_chacha20_poly1305() {
-    client_test(&TLS13, TLS13_CHACHA20_POLY1305_SHA256).await;
+    client_test(&TLS13, cipher_suite::TLS13_CHACHA20_POLY1305_SHA256).await;
 }
 
 #[tokio::test]
 async fn ktls_client_rustls_server_tls_1_2_ecdhe_aes_128_gcm() {
-    client_test(&TLS12, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256).await;
+    client_test(
+        &TLS12,
+        cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+    )
+    .await;
 }
 
 #[tokio::test]
 async fn ktls_client_rustls_server_tls_1_2_ecdhe_aes_256_gcm() {
-    client_test(&TLS12, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384).await;
+    client_test(
+        &TLS12,
+        cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+    )
+    .await;
 }
 
 #[tokio::test]
 async fn ktls_client_rustls_server_tls_1_2_ecdhe_chacha20_poly1305() {
-    client_test(&TLS12, TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256).await;
+    client_test(
+        &TLS12,
+        cipher_suite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+    )
+    .await;
 }
 
 enum ClientTestFlavor {
@@ -375,17 +385,18 @@ async fn client_test_inner(
     println!("{}", cert.serialize_pem().unwrap());
     println!("{}", cert.serialize_private_key_pem());
 
-    let mut server_config = ServerConfig::builder()
-        .with_cipher_suites(&[cipher_suite])
-        .with_safe_default_kx_groups()
-        .with_protocol_versions(&[protocol_version])
-        .unwrap()
-        .with_no_client_auth()
-        .with_single_cert(
-            vec![rustls::Certificate(cert.serialize_der().unwrap())],
-            rustls::PrivateKey(cert.serialize_private_key_der()),
-        )
-        .unwrap();
+    let mut server_config = ServerConfig::builder_with_provider(Arc::new(CryptoProvider {
+        cipher_suites: vec![cipher_suite],
+        ..rustls::crypto::ring::default_provider()
+    }))
+    .with_protocol_versions(&[protocol_version])
+    .unwrap()
+    .with_no_client_auth()
+    .with_single_cert(
+        vec![CertificateDer::from(cert.serialize_der().unwrap())],
+        rustls::pki_types::PrivatePkcs8KeyDer::from(cert.serialize_private_key_der()).into(),
+    )
+    .unwrap();
 
     server_config.key_log = Arc::new(rustls::KeyLogFile::new());
     // server_config.send_tls13_tickets = 0;
@@ -434,17 +445,13 @@ async fn client_test_inner(
         .instrument(tracing::info_span!("server")),
     );
 
-    let mut root_certs = RootCertStore::empty();
-    root_certs
-        .add(&rustls::Certificate(cert.serialize_der().unwrap()))
+    let mut root_store = RootCertStore::empty();
+    root_store
+        .add(CertificateDer::from(cert.serialize_der().unwrap()))
         .unwrap();
 
     let mut client_config = ClientConfig::builder()
-        .with_safe_default_cipher_suites()
-        .with_safe_default_kx_groups()
-        .with_safe_default_protocol_versions()
-        .unwrap()
-        .with_root_certificates(root_certs)
+        .with_root_certificates(root_store)
         .with_no_client_auth();
 
     client_config.enable_secret_extraction = true;


### PR DESCRIPTION
The API changed significanly, some knowledge about IV/salt/keys/etc. has disappeared from rustls proper so it has to be done here.

Also, we're affected by https://github.com/rustls/rustls/issues/1833 for the time being, and tokio-rustls still isn't on rustls 0.23.x 🤷 